### PR TITLE
A fix to the getters.

### DIFF
--- a/Patient.java
+++ b/Patient.java
@@ -14,19 +14,19 @@ public class Patient{
 
     // Getters
 
-    public String getFirstName(){
+     public ArrayList<String> getFirstName(){
         return this.firstName;
     }
 
-    public String getLastName(){
+    public ArrayList<String> getLastName(){
         return this.lastName;
     }
 
-    public String getBloodType(){
+    public ArrayList<String>  getBloodType(){
         return this.bloodType;
     }
 
-    public String getGender(){
+    public ArrayList<String>  getGender(){
         return this.gender;
     }
 


### PR DESCRIPTION
The getters are ultimately returning an ArrayList<String> so they should be set to that variable type. I don't know if that gave you an error on your end, but setting them to ArrayList<String> fixed the checked exception and satisfied the logical discrepancy I saw in it. Further input on the matter is appreciated. Everything works great though. Great job on the usage of the loop and StringBuilder.